### PR TITLE
Exclude bot updates from due date query

### DIFF
--- a/queries.yaml
+++ b/queries.yaml
@@ -22,5 +22,5 @@ queries:
     query: project_id=36&utf8=%E2%9C%93&set_filter=1&sort=updated_on%3Adesc&f%5B%5D=priority_id&op%5Bpriority_id%5D=%3D&v%5Bpriority_id%5D%5B%5D=4&f%5B%5D=status_id&op%5Bstatus_id%5D=o&f%5B%5D=updated_on&op%5Bupdated_on%5D=%3Ct-&v%5Bupdated_on%5D%5B%5D=365&f%5B%5D=subproject_id&op%5Bsubproject_id%5D=*&f%5B%5D=&c%5B%5D=subject&c%5B%5D=project&c%5B%5D=status&c%5B%5D=assigned_to&c%5B%5D=due_date&c%5B%5D=updated_on&c%5B%5D=category&group_by=&t%5B%5D=
     max: 0
   - title: Within due-date (10 days)
-    query: project_id=36&utf8=%E2%9C%93&set_filter=1&sort=updated_on%3Adesc&f%5B%5D=status_id&op%5Bstatus_id%5D=o&f%5B%5D=subproject_id&op%5Bsubproject_id%5D=*&f%5B%5D=due_date&op%5Bdue_date%5D=%3Ct-&v%5Bdue_date%5D%5B%5D=10&f%5B%5D=&c%5B%5D=subject&c%5B%5D=project&c%5B%5D=status&c%5B%5D=assigned_to&c%5B%5D=due_date&c%5B%5D=updated_on&c%5B%5D=category&group_by=&t%5B%5D=
+    query: project_id=36&utf8=%E2%9C%93&set_filter=1&sort=updated_on%3Adesc&f%5B%5D=status_id&op%5Bstatus_id%5D=o&f%5B%5D=subproject_id&op%5Bsubproject_id%5D=*&f%5B%5D=due_date&op%5Bdue_date%5D=%3Ct-&v%5Bdue_date%5D%5B%5D=10&f%5B%5D=last_updated_by&op%5Blast_updated_by%5D=%21&v%5Blast_updated_by%5D%5B%5D=40859&f%5B%5D=&c%5B%5D=subject&c%5B%5D=project&c%5B%5D=status&c%5B%5D=assigned_to&c%5B%5D=due_date&c%5B%5D=updated_on&c%5B%5D=category&group_by=&t%5B%5D=
     max: 0


### PR DESCRIPTION
The query filters by due date which is not reset automatically, so **Last updated by: slo-gin** is needed to prevent a cycle.

See: https://progress.opensuse.org/issues/113797